### PR TITLE
Add missing header file <ctime>

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -16,6 +16,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <cstring>
+#include <ctime>
 
 #include "env.h"
 #include "execute.h"


### PR DESCRIPTION
This patch adds the missing header file <ctime>, otherwise Clang will complain about it.

```
src/env.cpp:446:15: error: use of undeclared identifier 'clock_gettime'
    auto rc = clock_gettime(which_clock, &tp);
              ^
1 error generated.
make: *** [Makefile:71: build/env.o] Error 1
make: *** Waiting for unfinished jobs....
```